### PR TITLE
Fix malformed URL error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,10 @@
   "action": {
     "default_popup": "hello.html"
   },
-  "permissions": ["tabs", "*://*.github.com/*"],
+  "permissions": ["tabs"],
+  "host_permissions": [
+    "*://*.github.com/*"
+  ],
   "content_scripts": [
     {
       "matches": ["*://*.github.com/*/*/pull/*"],


### PR DESCRIPTION
Having permissions in host_permissions throws the error `Permission '*://*.github.com/*' is unknown or URL pattern is malformed.` Moving URLs to `host_permissions` fixes the error as mentioned in the stackoverflow answer here: https://stackoverflow.com/a/66867507/10043317