### PR TITLE
Multi-select dropdown + preset buttons

### DIFF
--- a/github-sonic-button.js
+++ b/github-sonic-button.js
@@ -1,36 +1,163 @@
 console.log("Running Sonic Buttons Code");
 
-function sonicButtonClick(event) {
-    const commentString = event.target.textContent;
-    document.getElementById('partial-new-comment-form-actions')
-    document.getElementById('new_comment_field').value = commentString;
-    document.getElementById("new_comment_form").submit();
-    document.getElementById('new_comment_field').value = "";
+async function submitSelectedCodes(codes, submitBtn) {
+    if (!codes || codes.length === 0) return;
+    const field = document.getElementById('new_comment_field');
+    const form  = document.getElementById('new_comment_form');
+    if (!field || !form) {
+        console.error("Sonic Buttons: comment form not found on page");
+        return;
+    }
+
+    const originalText = submitBtn ? submitBtn.textContent : null;
+    if (submitBtn) {
+        submitBtn.disabled = true;
+        submitBtn.textContent = `Submitting 0/${codes.length}…`;
+    }
+
+    let succeeded = 0;
+    for (let i = 0; i < codes.length; i++) {
+        const code = codes[i];
+        field.value = code;
+        const formData = new FormData(form);
+
+        let response;
+        try {
+            response = await fetch(form.action, {
+                method: form.method || 'POST',
+                body: formData,
+                credentials: 'same-origin',
+                redirect: 'follow',
+                headers: { 'Accept': 'text/html, application/xhtml+xml' }
+            });
+        } catch (err) {
+            console.error("Sonic Buttons: network error submitting", code, err);
+            break;
+        }
+
+        if (!response.ok) {
+            console.error("Sonic Buttons: server rejected", code, response.status);
+            break;
+        }
+        succeeded++;
+        if (submitBtn) submitBtn.textContent = `Submitting ${succeeded}/${codes.length}…`;
+
+        if (i < codes.length - 1) {
+            try {
+                const html = await response.text();
+                const doc = new DOMParser().parseFromString(html, 'text/html');
+                const refreshedForm = doc.getElementById('new_comment_form');
+                const refreshedTokenInput = refreshedForm
+                    ? refreshedForm.querySelector('input[name="authenticity_token"]')
+                    : null;
+                const currentTokenInput = form.querySelector('input[name="authenticity_token"]');
+                if (refreshedTokenInput && currentTokenInput) {
+                    currentTokenInput.value = refreshedTokenInput.value;
+                } else {
+                    console.warn("Sonic Buttons: could not refresh authenticity_token; remaining submissions may fail");
+                }
+            } catch (err) {
+                console.error("Sonic Buttons: failed to refresh token", err);
+                break;
+            }
+        }
+    }
+
+    field.value = "";
+    if (submitBtn && originalText !== null) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = originalText;
+    }
+    if (succeeded > 0) location.reload();
+}
+
+function buildCustomDropdown(codes) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "d-flex flex-items-center";
+
+    const details = document.createElement("details");
+    details.className = "details-reset details-overlay position-relative";
+
+    const summary = document.createElement("summary");
+    summary.className = "btn";
+    summary.style.minWidth = "100px";
+    summary.style.display = "inline-flex";
+    summary.style.alignItems = "center";
+    summary.style.justifyContent = "space-between";
+
+    const summaryLabel = document.createElement("span");
+    summaryLabel.textContent = "Sonic";
+    const summaryCaret = document.createElement("span");
+    summaryCaret.textContent = "▾";
+    summary.appendChild(summaryLabel);
+    summary.appendChild(summaryCaret);
+
+    details.appendChild(summary);
+
+    const menu = document.createElement("div");
+    menu.className = "SelectMenu position-absolute";
+    menu.style.zIndex = "100";
+    menu.style.marginTop = "4px";
+
+    const modal = document.createElement("div");
+    modal.className = "SelectMenu-modal";
+    modal.style.minWidth = "300px";
+
+    const list = document.createElement("div");
+    list.className = "SelectMenu-list";
+    list.style.maxHeight = "300px";
+    list.style.overflowY = "auto";
+    list.style.padding = "4px 0";
+
+    for (const code of codes) {
+        const label = document.createElement("label");
+        label.className = "SelectMenu-item";
+        label.style.cursor = "pointer";
+        label.style.display = "flex";
+        label.style.alignItems = "center";
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.value = code;
+        checkbox.className = "mr-2";
+
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(code));
+        list.appendChild(label);
+    }
+
+    modal.appendChild(list);
+    menu.appendChild(modal);
+    details.appendChild(menu);
+    wrapper.appendChild(details);
+
+    const submitBtn = document.createElement("button");
+    submitBtn.type = "button";
+    submitBtn.className = "btn btn-primary ml-1";
+    submitBtn.textContent = "Submit";
+    submitBtn.addEventListener("click", function () {
+        const checked = list.querySelectorAll('input[type="checkbox"]:checked');
+        const selected = Array.from(checked).map(c => c.value);
+        submitSelectedCodes(selected, submitBtn);
+    });
+    wrapper.appendChild(submitBtn);
+
+    return wrapper;
 }
 
 const parentDiv = document.getElementById("issue-comment-box");
-//const targetDiv = parentDiv.querySelector(".d-flex.flex-justify-end");
 
 chrome.storage.local.get(['userMessage'], function (result) {
     let commentButtonTexts = ["RUN_SCA", "RUN_UNIT_TESTS"];
     if (result.userMessage) {
-        commentButtonTexts = result.userMessage.split(",").map(e => e.trim());
+        commentButtonTexts = result.userMessage.split(",").map(e => e.trim()).filter(Boolean);
     }
-    const sonicButtonDiv = document.createElement("div");
-    sonicButtonDiv.className = "d-flex ml-2 pl-7"; // Set class attribute
 
-    for (let i = 0; i < commentButtonTexts.length; i++) {
-        const commentButtonText = commentButtonTexts[i]
-        const newDiv = document.createElement("div");
-        newDiv.className = "mr-1"; // Set class attribute
-        const newButton = document.createElement("button");
-        newButton.id = "sonic_sca_click";
-        newButton.type ="button";
-        newButton.className = "btn"; // Set class attribute
-        newButton.textContent = commentButtonText;
-        newButton.addEventListener("click", sonicButtonClick);
-        newDiv.appendChild(newButton);
-        sonicButtonDiv.appendChild(newDiv)
-    }
-    parentDiv.insertBefore(sonicButtonDiv, parentDiv.firstChild);
+    const sonicContainer = document.createElement("div");
+    sonicContainer.className = "d-flex flex-items-center flex-justify-end";
+    sonicContainer.style.padding = "8px 0";
+
+    sonicContainer.appendChild(buildCustomDropdown(commentButtonTexts));
+
+    parentDiv.insertBefore(sonicContainer, parentDiv.firstChild);
 });

--- a/github-sonic-button.js
+++ b/github-sonic-button.js
@@ -1,5 +1,13 @@
 console.log("Running Sonic Buttons Code");
 
+const PRESETS = [
+    { label: "RUN_FRONTEND_CHECKS",   codes: ["RUN_COVERAGE_CHECK", "RUN_FRONTEND_VALIDATION", "RUN_SCA"] },
+    { label: "RUN_TESTSTACK_CHECKS",  codes: ["RUN_SCA", "RUN_SYNTAX_CHECK", "RUN_UNIT_TEST", "RUN_OPENAPI_CHECK"] },
+    { label: "RUN_TESTHUB_CHECKS",    codes: ["RUN_SCA", "RUN_CHECKS", "RUN_UNIT_TESTS", "RUN_API_TESTS"] },
+    { label: "RUN_SDK_CHECKS",        codes: ["RUN_SCA"] },
+    { label: "RUN_AUTOMATION_CHECKS", codes: ["RUN_QUALITY_CHECKS"] },
+];
+
 async function submitSelectedCodes(codes, submitBtn) {
     if (!codes || codes.length === 0) return;
     const field = document.getElementById('new_comment_field');
@@ -73,7 +81,12 @@ async function submitSelectedCodes(codes, submitBtn) {
 
 function buildCustomDropdown(codes) {
     const wrapper = document.createElement("div");
-    wrapper.className = "d-flex flex-items-center";
+    wrapper.className = "d-flex flex-column flex-items-center";
+    wrapper.style.paddingTop = "6px";
+    wrapper.style.gap = "4px";
+
+    const topRow = document.createElement("div");
+    topRow.className = "d-flex flex-items-center";
 
     const details = document.createElement("details");
     details.className = "details-reset details-overlay position-relative";
@@ -86,7 +99,7 @@ function buildCustomDropdown(codes) {
     summary.style.justifyContent = "space-between";
 
     const summaryLabel = document.createElement("span");
-    summaryLabel.textContent = "Sonic";
+    summaryLabel.textContent = "Custom";
     const summaryCaret = document.createElement("span");
     summaryCaret.textContent = "▾";
     summary.appendChild(summaryLabel);
@@ -94,14 +107,19 @@ function buildCustomDropdown(codes) {
 
     details.appendChild(summary);
 
+    function updateSelectedCount() {
+        const count = list.querySelectorAll('input[type="checkbox"]:checked').length;
+        summaryLabel.textContent = count > 0 ? `Custom (${count})` : "Custom";
+    }
+
     const menu = document.createElement("div");
     menu.className = "SelectMenu position-absolute";
     menu.style.zIndex = "100";
-    menu.style.marginTop = "4px";
 
     const modal = document.createElement("div");
     modal.className = "SelectMenu-modal";
     modal.style.minWidth = "300px";
+    modal.style.marginTop = "0.25rem";
 
     const list = document.createElement("div");
     list.className = "SelectMenu-list";
@@ -126,10 +144,12 @@ function buildCustomDropdown(codes) {
         list.appendChild(label);
     }
 
+    list.addEventListener("change", updateSelectedCount);
+
     modal.appendChild(list);
     menu.appendChild(modal);
     details.appendChild(menu);
-    wrapper.appendChild(details);
+    topRow.appendChild(details);
 
     const submitBtn = document.createElement("button");
     submitBtn.type = "button";
@@ -140,7 +160,46 @@ function buildCustomDropdown(codes) {
         const selected = Array.from(checked).map(c => c.value);
         submitSelectedCodes(selected, submitBtn);
     });
-    wrapper.appendChild(submitBtn);
+    topRow.appendChild(submitBtn);
+
+    wrapper.appendChild(topRow);
+
+    const branding = document.createElement("div");
+    branding.className = "d-flex flex-items-center color-fg-muted";
+    branding.style.gap = "6px";
+    branding.style.fontSize = "12px";
+
+    const brandingIcon = document.createElement("img");
+    brandingIcon.src = chrome.runtime.getURL("assets/icon-16.png");
+    brandingIcon.alt = "";
+    brandingIcon.style.width = "16px";
+    brandingIcon.style.height = "16px";
+
+    const brandingText = document.createElement("span");
+    brandingText.textContent = "Sonic Buttons";
+
+    branding.appendChild(brandingIcon);
+    branding.appendChild(brandingText);
+    wrapper.appendChild(branding);
+
+    return wrapper;
+}
+
+function buildPresets() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "d-flex flex-wrap flex-items-center";
+    wrapper.style.gap = "4px";
+
+    for (const preset of PRESETS) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "btn";
+        btn.textContent = preset.label;
+        btn.addEventListener("click", function () {
+            submitSelectedCodes(preset.codes, btn);
+        });
+        wrapper.appendChild(btn);
+    }
 
     return wrapper;
 }
@@ -154,10 +213,22 @@ chrome.storage.local.get(['userMessage'], function (result) {
     }
 
     const sonicContainer = document.createElement("div");
-    sonicContainer.className = "d-flex flex-items-center flex-justify-end";
-    sonicContainer.style.padding = "8px 0";
+    sonicContainer.className = "d-flex flex-items-start flex-justify-between ml-6 pl-7";
+    sonicContainer.style.paddingTop = "8px";
+    sonicContainer.style.paddingBottom = "8px";
+    sonicContainer.style.gap = "8px";
 
-    sonicContainer.appendChild(buildCustomDropdown(commentButtonTexts));
+    const separator = document.createElement("div");
+    separator.style.width = "1px";
+    separator.style.alignSelf = "stretch";
+    separator.style.backgroundColor = "var(--color-border-default, #d0d7de)";
+
+    const presetCodes = PRESETS.flatMap(p => p.codes);
+    const dropdownCodes = [...new Set([...commentButtonTexts, ...presetCodes])];
+
+    sonicContainer.appendChild(buildPresets());
+    sonicContainer.appendChild(separator);
+    sonicContainer.appendChild(buildCustomDropdown(dropdownCodes));
 
     parentDiv.insertBefore(sonicContainer, parentDiv.firstChild);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,11 @@
     "16": "assets/icon-16.png",
     "48": "assets/icon-48.png",
     "128": "assets/icon-128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["assets/icon-16.png"],
+      "matches": ["*://*.github.com/*"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Two long-standing UX gaps on PR pages:

- **Horizontal overflow.** The old per-code button row used `d-flex` with no wrap; adding many codes pushed buttons off-screen.
- **Multi-comment friction.** Each click called `#new_comment_form.submit()` directly and reloaded the page, so posting several codes required racing clicks before the first reload landed.

This PR replaces the per-code button row with two flows:

- **Preset buttons (left).** Five hard-coded shortcuts (`RUN_FRONTEND_CHECKS`, `RUN_TESTSTACK_CHECKS`, `RUN_TESTHUB_CHECKS`, `RUN_SDK_CHECKS`, `RUN_AUTOMATION_CHECKS`) that each fan out to a fixed list of codes. The row wraps onto multiple lines when it outgrows the available width.
- **Custom dropdown (right).** A Primer-styled `<details>` disclosure with a scrollable checkbox panel listing the union of stored codes and unique preset codes. The trigger shows a live count (`Custom`, `Custom (3)`). A single Submit button posts all checked codes.

Submission no longer uses raw `form.submit()` in a loop (which the browser cancels mid-flight, only posting the last comment). Instead, `submitSelectedCodes` POSTs each code via `fetch(form.action, { body: new FormData(form), credentials: 'same-origin' })`, parses the response HTML to extract a fresh `authenticity_token` for the next request, and calls `location.reload()` once at the end. Same-origin only — no new host permissions.

Also adds a small "Sonic Buttons" branding row (icon + label) inside the dropdown column. Required `web_accessible_resources` for `assets/icon-16.png`.

## Test plan

- [ ] Load the unpacked extension and open a GitHub PR page; preset row appears on the left, Custom dropdown on the right, branding below the Submit button.
- [ ] Click any preset; all of its mapped codes post as separate comments and the page reloads once.
- [ ] Open Custom dropdown, tick 3 codes; trigger shows `Custom (3)`; clicking Submit posts all 3 as separate comments.
- [ ] Verify ~15 stored codes don't overflow horizontally; dropdown list scrolls inside the panel.
- [ ] Existing popup add/remove flow still updates the dropdown list on next page load.
- [ ] Empty selection on Custom Submit is a no-op (no field write, no fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)